### PR TITLE
Fix: Defer operations in BREAKING checkbox listener

### DIFF
--- a/index.html
+++ b/index.html
@@ -268,8 +268,12 @@
 
                         if (keywordStateToUpdate) {
                             keywordStateToUpdate.requiresBreaking = checkboxIsChecked;
-                            resetKeywordStats(keywordStateToUpdate);
-                            saveSettings();
+
+                            // Defer subsequent actions slightly
+                            setTimeout(() => {
+                                resetKeywordStats(keywordStateToUpdate);
+                                saveSettings();
+                            }, 0);
                         } else {
                             console.error("Breaking checkbox: Could not find keyword state for key:", currentKeyForListener);
                         }


### PR DESCRIPTION
Wrapped resetKeywordStats and saveSettings calls in a setTimeout(..., 0) within the BREAKING checkbox 'change' event listener.

This aims to resolve an issue where the checkbox was unresponsive, potentially due to synchronous DOM updates or layout changes interfering with the native checkbox toggle action. This commit is for enabling localhost testing of this specific fix.